### PR TITLE
feat, bug-fix: Added draggable symbols to course and year components, made filter auto open, bug squashing

### DIFF
--- a/src/components/dashboard/course-list/CourseComponent.tsx
+++ b/src/components/dashboard/course-list/CourseComponent.tsx
@@ -1,24 +1,12 @@
 import React, { useState, useEffect } from "react";
 import ReactTooltip from "react-tooltip";
-import {
-  UserCourse,
-  SemesterType,
-  Course,
-  Year,
-} from "../../../resources/commonTypes";
+import { UserCourse, SemesterType, Year } from "../../../resources/commonTypes";
 import { checkAllPrereqs, getColors } from "../../../resources/assets";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  updateInspectedCourse,
-  updateSearchTime,
-  updateSearchTerm,
-  updatePlaceholder,
-  updateInspectedVersion,
-  updateSearchStatus,
-} from "../../../slices/searchSlice";
 import { ReactComponent as RemoveSvg } from "../../../resources/svg/Remove.svg";
 import { ReactComponent as DetailsSvg } from "../../../resources/svg/Details.svg";
 import { ReactComponent as WarningSvg } from "../../../resources/svg/Warning.svg";
+import { ReactComponent as GrabSvg } from "../../../resources/svg/Grab.svg";
 import { Transition } from "@tailwindui/react";
 import clsx from "clsx";
 import "react-toastify/dist/ReactToastify.css";
@@ -36,6 +24,7 @@ import {
 } from "../../../slices/popupSlice";
 
 type courseProps = {
+  setDraggable: Function;
   course: UserCourse;
   year: Year;
   semester: SemesterType;
@@ -43,16 +32,23 @@ type courseProps = {
 
 /**
  * This is a course card displayed in the course list under each semester.
+ * @param setDraggable: to determine if we can drag this item.
  * @param course: course it's displaying
  * @param year: year the course is part of
  * @param semester: semester this course is part of
  */
-function CourseComponent({ year, course, semester }: courseProps) {
+function CourseComponent({
+  setDraggable,
+  year,
+  course,
+  semester,
+}: courseProps) {
   // React setup
   const [activated, setActivated] = useState<boolean>(false);
   const [satisfied, setSatisfied] = useState<boolean>(false);
   const [overridden, setOverridden] = useState<boolean>(false);
   const [displayPopup, setDisplayPopup] = useState<boolean>(false);
+  const [hovered, setHovered] = useState<boolean>(false);
 
   // Redux setup
   const dispatch = useDispatch();
@@ -85,38 +81,6 @@ function CourseComponent({ year, course, semester }: courseProps) {
   const displayCourses = () => {
     dispatch(updateCourseToShow(course));
     dispatch(updateShowCourseInfo(true));
-    // dispatch(
-    //   updateSearchTime({ searchYear: year._id, searchSemester: semester })
-    // );
-    // dispatch(updateSearchTerm(course.number));
-    // let found = false;
-    // allCourses.forEach((c) => {
-    //   if (c.number === course.number) {
-    //     dispatch(updateInspectedCourse(c));
-    //     dispatch(updatePlaceholder(false));
-    //     found = true;
-    //   }
-    // });
-    // if (!found) {
-    //   const placeholderCourse: Course = {
-    //     title: course.title,
-    //     number: course.number,
-    //     areas: course.area,
-    //     term: "",
-    //     school: "none",
-    //     department: "none",
-    //     credits: course.credits.toString(),
-    //     wi: false,
-    //     bio: "This is a placeholder course",
-    //     tags: [],
-    //     preReq: [],
-    //     restrictions: [],
-    //     level: "",
-    //   };
-    //   dispatch(updatePlaceholder(true));
-    //   dispatch(updateInspectedVersion(placeholderCourse));
-    // }
-    // dispatch(updateSearchStatus(true));
   };
 
   // Deletes a course on click of the delete button. Updates currently displayed plan with changes.
@@ -127,10 +91,12 @@ function CourseComponent({ year, course, semester }: courseProps) {
 
   const activate = () => {
     setActivated(true);
+    setTimeout(() => setHovered(true), 100);
   };
 
   const deactivate = () => {
     setActivated(false);
+    setHovered(false);
   };
 
   const tooltip = `<div>Prereqs not yet satisfied</div>`;
@@ -190,8 +156,20 @@ function CourseComponent({ year, course, semester }: courseProps) {
                 )}
               >
                 <div className="absolute left-0 top-0 w-full h-full bg-white bg-opacity-80 rounded" />
+                <div
+                  className={clsx(
+                    "absolute z-20 left-0 w-0 h-full bg-blue-400 bg-opacity-80 rounded transform duration-150 ease-in",
+                    {
+                      "w-1/4": hovered,
+                    }
+                  )}
+                  onMouseEnter={() => setDraggable(false)}
+                  onMouseLeave={() => setDraggable(true)}
+                >
+                  <GrabSvg className="p-auto py-auto z-20 m-auto w-6 h-full text-white" />
+                </div>
                 <DetailsSvg
-                  className="relative z-20 flex flex-row items-center justify-center mr-5 p-0.5 w-6 h-6 text-white bg-secondary rounded-md outline-none stroke-2 cursor-pointer transform hover:scale-110 transition duration-150 ease-in"
+                  className="relative z-20 flex flex-row items-center justify-center ml-12 mr-5 p-0.5 w-6 h-6 text-white bg-secondary rounded-md outline-none stroke-2 cursor-pointer transform hover:scale-110 transition duration-150 ease-in"
                   onClick={displayCourses}
                 />
                 <RemoveSvg

--- a/src/components/dashboard/course-list/CourseDraggable.tsx
+++ b/src/components/dashboard/course-list/CourseDraggable.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { Draggable } from "react-beautiful-dnd";
+import { SemesterType, UserCourse, Year } from "../../../resources/commonTypes";
+import CourseComponent from "./CourseComponent";
+
+type CourseDraggableProps = {
+  course: UserCourse;
+  index: number;
+  semesterYear: Year;
+  semesterName: SemesterType;
+};
+
+const CourseDraggable = ({
+  course,
+  index,
+  semesterYear,
+  semesterName,
+}: CourseDraggableProps) => {
+  const [draggable, setDraggable] = useState<boolean>(true);
+  return (
+    <Draggable
+      key={course._id}
+      index={index}
+      draggableId={course._id}
+      isDragDisabled={draggable}
+    >
+      {(provided, snapshot) => {
+        return (
+          <div
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+            style={getItemStyle(
+              snapshot.isDragging,
+              provided.draggableProps.style
+            )}
+          >
+            <CourseComponent
+              setDraggable={setDraggable}
+              year={semesterYear}
+              course={course}
+              semester={semesterName}
+            />
+          </div>
+        );
+      }}
+    </Draggable>
+  );
+};
+
+const getItemStyle = (isDragging: any, draggableStyle: any) => ({
+  // some basic styles to make the items look a bit nicer
+  userSelect: "none",
+
+  // styles we need to apply on draggables
+  ...draggableStyle,
+});
+
+export default CourseDraggable;

--- a/src/components/dashboard/course-list/CourseList.tsx
+++ b/src/components/dashboard/course-list/CourseList.tsx
@@ -32,7 +32,7 @@ import {
   updatePlanList,
 } from "../../../slices/userSlice";
 import { api } from "../../../resources/assets";
-import { DragDropContext, Droppable } from "react-beautiful-dnd";
+import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 import YearDraggable from "./YearDraggable";
 
 /**
@@ -74,11 +74,13 @@ function CourseList() {
           });
           jsx.push(
             <YearDraggable
+              id={yearIndex}
               year={year}
               yearIndex={yearIndex}
               yearCourses={yearCourses}
             />
           );
+          console.log("Same Year is ", yearIndex, year);
           if (jsx.length === currentPlan.years.length) {
             jsx.sort(
               (el1: JSX.Element, el2: JSX.Element) =>
@@ -101,16 +103,17 @@ function CourseList() {
                   // make all the updates here
                   jsx.push(
                     <YearDraggable
+                      id={yearIndex}
                       year={year}
                       yearIndex={yearIndex}
                       yearCourses={yearCourses}
                     />
                   );
                   if (jsx.length === currentPlan.years.length) {
-                    // jsx.sort(
-                    //   (el1: JSX.Element, el2: JSX.Element) =>
-                    //     el1.props.id - el2.props.id
-                    // );
+                    jsx.sort(
+                      (el1: JSX.Element, el2: JSX.Element) =>
+                        el1.props.id - el2.props.id
+                    );
                     dispatch(updateCurrentPlanCourses(totCourses));
                     setElements(jsx);
                   }
@@ -377,29 +380,38 @@ function CourseList() {
     <>
       <DragDropContext onDragEnd={onDragEnd}>
         <div className="flex flex-row flex-wrap justify-between thin:justify-center mt-4 w-full h-auto">
-          {/* {currentPlan._id !== "noPlan" ? (
-            <AddSvg
-              onClick={() => addNewYear(true)}
-              className="-mt-1 mb-4 mr-3 w-14 h-auto max-h-48 border-2 border-gray-300 rounded focus:outline-none cursor-pointer select-none transform hover:scale-105 transition duration-200 ease-in"
-              data-tip={`Add a pre-university year!`}
-              data-for="godTip"
-            />
-          ) : null} */}
           <Droppable droppableId={"years"} type="YEAR" direction="horizontal">
             {(provided, snapshot) => (
               <div
                 ref={provided.innerRef}
-                className="flex-wrap rounded"
+                className="flex-grow flex-wrap rounded"
                 style={getListStyle(snapshot.isDraggingOver)}
               >
                 {elements}
                 {currentPlan._id !== "noPlan" ? (
-                  <AddSvg
-                    onClick={() => addNewYear(false)}
-                    className="min-h-addSVG -mt-1 mb-4 ml-5 mr-5 w-14 h-auto max-h-48 border-2 border-gray-300 rounded focus:outline-none cursor-pointer select-none transform hover:scale-105 transition duration-200 ease-in"
-                    data-tip={`Add an additional year after!`}
-                    data-for="godTip"
-                  />
+                  <Draggable
+                    index={currentPlan.years.length}
+                    key="addButton"
+                    draggableId={"addButton"}
+                    isDragDisabled={true}
+                  >
+                    {(provided, snapshot) => {
+                      return (
+                        <div
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                        >
+                          <AddSvg
+                            onClick={() => addNewYear(false)}
+                            className="-mt-1 mb-4 ml-5 mr-5 w-14 h-auto max-h-48 min-h-addSVG border-2 border-gray-300 rounded focus:outline-none cursor-pointer select-none transform hover:scale-105 transition duration-200 ease-in"
+                            data-tip={`Add an additional year after!`}
+                            data-for="godTip"
+                          />
+                        </div>
+                      );
+                    }}
+                  </Draggable>
                 ) : null}
                 {provided.placeholder}
               </div>

--- a/src/components/dashboard/course-list/Semester.tsx
+++ b/src/components/dashboard/course-list/Semester.tsx
@@ -5,17 +5,17 @@ import {
   UserCourse,
   Year,
 } from "../../../resources/commonTypes";
-import CourseComponent from "./CourseComponent";
 import { useDispatch } from "react-redux";
 import {
   updateSearchStatus,
   updateSearchTime,
 } from "../../../slices/searchSlice";
 import { ReactComponent as AddSvg } from "../../../resources/svg/Add.svg";
-import { Droppable, Draggable } from "react-beautiful-dnd";
+import { Droppable } from "react-beautiful-dnd";
 import { updateDroppables } from "../../../slices/currentPlanSlice";
 import ReactTooltip from "react-tooltip";
 import clsx from "clsx";
+import CourseDraggable from "./CourseDraggable";
 
 type semesterProps = {
   customStyle: string;
@@ -85,27 +85,12 @@ function Semester({
 
   const getDraggables = () => {
     return semesterCourses.map((course, index) => (
-      <Draggable key={course._id} index={index} draggableId={course._id}>
-        {(provided, snapshot) => {
-          return (
-            <div
-              ref={provided.innerRef}
-              {...provided.draggableProps}
-              {...provided.dragHandleProps}
-              style={getItemStyle(
-                snapshot.isDragging,
-                provided.draggableProps.style
-              )}
-            >
-              <CourseComponent
-                year={semesterYear}
-                course={course}
-                semester={semesterName}
-              />
-            </div>
-          );
-        }}
-      </Draggable>
+      <CourseDraggable
+        course={course}
+        index={index}
+        semesterName={semesterName}
+        semesterYear={semesterYear}
+      />
     ));
   };
 
@@ -190,14 +175,6 @@ function Semester({
 
 const getListStyle = (isDraggingOver: any) => ({
   background: isDraggingOver ? "skyblue" : "lightblue",
-});
-
-const getItemStyle = (isDragging: any, draggableStyle: any) => ({
-  // some basic styles to make the items look a bit nicer
-  userSelect: "none",
-
-  // styles we need to apply on draggables
-  ...draggableStyle,
 });
 
 export default Semester;

--- a/src/components/dashboard/course-list/YearComponent.tsx
+++ b/src/components/dashboard/course-list/YearComponent.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import Semester from "./Semester";
 import { UserCourse, Year } from "../../../resources/commonTypes";
 import { ReactComponent as MoreSvg } from "../../../resources/svg/More.svg";
+import { ReactComponent as GrabSvg } from "../../../resources/svg/Grab.svg";
 import { useSelector, useDispatch } from "react-redux";
 import {
   selectPlan,
@@ -19,6 +20,7 @@ type yearProps = {
   customStyle: string;
   year: Year;
   courses: UserCourse[];
+  setDraggable: Function;
 };
 
 export const newYearTemplate: Year = {
@@ -38,7 +40,13 @@ export const newYearTemplate: Year = {
  * @param year - the year designator
  * @param courses - courses that belong to this year
  */
-function YearComponent({ id, customStyle, year, courses }: yearProps) {
+function YearComponent({
+  id,
+  customStyle,
+  year,
+  courses,
+  setDraggable,
+}: yearProps) {
   // Component state setup.
   const [fallCourses, setFallCourses] = useState<UserCourse[]>([]);
   const [springCourses, setSpringCourses] = useState<UserCourse[]>([]);
@@ -48,6 +56,7 @@ function YearComponent({ id, customStyle, year, courses }: yearProps) {
   const [hide, setHide] = useState<boolean>(false);
   const [yearName, setYearName] = useState<string>(year.name);
   const [semSelect, setSemSelect] = useState<boolean>(false);
+  const [onHover, setOnHover] = useState<boolean>(false);
   // Determines whether we're editing the name.
   const [editedName, setEditedName] = useState<boolean>(false);
   const [edittingName, setEdittingName] = useState<boolean>(false);
@@ -174,14 +183,37 @@ function YearComponent({ id, customStyle, year, courses }: yearProps) {
           onMouseLeave={() => {
             setDisplay(false);
             setSemSelect(false);
+            setOnHover(false);
+          }}
+          onMouseEnter={() => {
+            if (!edittingName) setOnHover(true);
           }}
         >
           <div className="flex flex-row justify-between px-0.5 w-full bg-white">
+            <div
+              className={clsx(
+                "mt-1 h-5 rounded transform duration-150 ease-in",
+                {
+                  "mr-1 h-5 bg-blue-400": onHover,
+                }
+              )}
+              onMouseEnter={() => setDraggable(false)}
+              onMouseLeave={() => setDraggable(true)}
+            >
+              <GrabSvg
+                className={clsx(
+                  "py-auto m-auto h-0 text-white transform duration-150 ease-in",
+                  {
+                    "h-5": onHover,
+                  }
+                )}
+              />
+            </div>
             <input
               id={year._id + "input"}
               value={yearName}
               className={clsx(
-                "flex-shrink mt-auto w-full text-lg font-semibold bg-white border-b focus:border-gray-400 border-transparent focus:outline-none select-none select-none"
+                "flex-shrink mt-auto w-full text-lg font-semibold bg-white border-b focus:border-gray-400 border-transparent focus:outline-none select-none"
               )}
               onChange={handleYearNameChange}
               disabled={!edittingName}
@@ -207,6 +239,7 @@ function YearComponent({ id, customStyle, year, courses }: yearProps) {
                     onClick={() => {
                       setEdittingName(true);
                       setDisplay(false);
+                      setOnHover(false);
                     }}
                     className="hover:bg-gray-300 focus:outline-none"
                   >

--- a/src/components/dashboard/course-list/YearDraggable.tsx
+++ b/src/components/dashboard/course-list/YearDraggable.tsx
@@ -1,24 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import { Draggable } from "react-beautiful-dnd";
 import { UserCourse, Year } from "../../../resources/commonTypes";
 import YearComponent from "./YearComponent";
 
 /**
  * The year draggable for shifting around year ordering.
+ * @param id - The index of the year among the other years.
  * @param year - The year contained in the draggable.
  * @param yearIndex - The index of the year among the other years.
  * @param yearCourses - The courses contained in the year.
  */
 const YearDraggable = (props: {
+  id: number;
   year: Year;
   yearIndex: number;
   yearCourses: UserCourse[];
 }) => {
+  const [draggable, setDraggable] = useState<boolean>(true);
   return (
     <Draggable
       key={props.year._id}
       index={props.yearIndex}
       draggableId={props.year._id}
+      isDragDisabled={draggable}
     >
       {(provided, snapshot) => {
         return (
@@ -34,9 +38,10 @@ const YearDraggable = (props: {
             <YearComponent
               key={props.year._id}
               id={props.yearIndex}
-              customStyle="cursor-pointer"
+              customStyle=""
               year={props.year}
               courses={props.yearCourses}
+              setDraggable={setDraggable}
             />
           </div>
         );

--- a/src/components/popups/course-search/prereqs/PrereqDisplay.tsx
+++ b/src/components/popups/course-search/prereqs/PrereqDisplay.tsx
@@ -22,6 +22,7 @@ import {
   selectPlan,
 } from "../../../../slices/currentPlanSlice";
 import { selectAllCourses } from "../../../../slices/userSlice";
+import { selectCourseToShow } from "../../../../slices/popupSlice";
 
 // Parsed prereq type
 // satisfied: a boolean that tells whether the prereq should be marked with green (satisfied) or red (unsatisfied)
@@ -44,6 +45,7 @@ const PrereqDisplay = () => {
   const year = useSelector(selectYear);
   const currentPlan = useSelector(selectPlan);
   const allCourses = useSelector(selectAllCourses);
+  const courseToShow = useSelector(selectCourseToShow);
 
   // Component states
   const [prereqDisplayMode, setPrereqDisplayMode] = useState(2);
@@ -52,7 +54,7 @@ const PrereqDisplay = () => {
   const [hasPreReqs, setHasPreReqs] = useState<boolean>(false);
   const [NNegativePreReqs, setNNegativePreReqs] = useState<any[]>();
 
-  const display = async (preReqs: any[]) => {
+  const display = (preReqs: any[]) => {
     const prereqs = processPrereqs(preReqs, allCourses, currPlanCourses);
     afterGathering(prereqs.numNameList, prereqs.numList, prereqs.expr);
   };
@@ -148,11 +150,12 @@ const PrereqDisplay = () => {
       // If the element is a number
       const noCBrackets: string = element.substr(0, element.length - 3);
       const noCBracketsNum: string = element.substr(0, 10);
-      const satisfied: boolean = checkPrereq(
+      const yearToCheck = courseToShow !== null ? courseToShow.year_id : year;
+      let satisfied: boolean = checkPrereq(
         currPlanCourses,
         currentPlan,
         noCBracketsNum,
-        year,
+        yearToCheck,
         semester
       );
       return {

--- a/src/components/popups/course-search/query-components/Filters.tsx
+++ b/src/components/popups/course-search/query-components/Filters.tsx
@@ -277,7 +277,15 @@ const Filters = ({ showCriteria }: filterProps) => {
                   label: wi,
                 })),
               ]}
-              value={{ value: searchFilters.wi, label: searchFilters.wi }}
+              value={{
+                value: searchFilters.wi,
+                label:
+                  searchFilters.wi === null
+                    ? "Any"
+                    : searchFilters.wi
+                    ? "True"
+                    : "False",
+              }}
               className="w-40 rounded outline-none"
               onChange={handleWIFilterChange}
             />

--- a/src/components/popups/course-search/query-components/Form.tsx
+++ b/src/components/popups/course-search/query-components/Form.tsx
@@ -37,7 +37,7 @@ const Form = (props: { setSearching: Function }) => {
   const allCourses = useSelector(selectAllCourses);
 
   // Component state setup
-  const [showCriteria, setShowCriteria] = useState(false);
+  const [showCriteria, setShowCriteria] = useState(true);
   const [showAllResults, setShowAllResults] = useState<boolean>(false);
   const [searchedCourses] = useState<Map<String, SearchMapEl>>(
     new Map<String, SearchMapEl>()

--- a/src/resources/assets.tsx
+++ b/src/resources/assets.tsx
@@ -668,6 +668,7 @@ export const checkPrereq = (
 ): boolean => {
   let satisfied: boolean = false;
   const yearObj = getYearFromId(year, plan);
+  console.log("checking prereq", yearObj, year);
 
   courses.forEach((course) => {
     if (
@@ -714,6 +715,7 @@ const prereqInPast = (
   const retrievedYear = getCourseYear(plan, course);
   if (retrievedYear !== null) {
     const courseYearRank: number = getYearIndex(retrievedYear, plan);
+    console.log("two are", year, courseYearRank, course);
     if (courseYearRank < year) {
       return true;
     } else if (courseYearRank > year) {

--- a/src/resources/svg/Grab.svg
+++ b/src/resources/svg/Grab.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11" />
+</svg>


### PR DESCRIPTION
Draggable symbols
- Implemented to make dragging more intuitive
![image](https://user-images.githubusercontent.com/65636118/129464722-156a3b66-428f-4ac3-aa87-e441325d2e3f.png)
![image](https://user-images.githubusercontent.com/65636118/129464731-60bdcb89-e0ad-440c-9dd8-3a7ac346dd61.png)

Filter now auto-opens on opening search popout
![image](https://user-images.githubusercontent.com/65636118/129464748-136bfd70-0d65-4e6e-9669-db400a966950.png)

Bug squashes
- Prereqs weren't being displayed correctly when opening courses from plan dashboard.
- Years were being randomized when switching plans.