### PR TITLE
feat: Added arrows to toggle opening and closing search filter and plan semester courses, added descriptions that open on hover over placeholder, areas, tags, year version toggling, and add year; other small tweaks

### DIFF
--- a/src/components/dashboard/course-list/Semester.tsx
+++ b/src/components/dashboard/course-list/Semester.tsx
@@ -11,6 +11,8 @@ import {
   updateSearchTime,
 } from "../../../slices/searchSlice";
 import { ReactComponent as AddSvg } from "../../../resources/svg/Add.svg";
+import { ReactComponent as ArrowUp } from "../../../resources/svg/ArrowUp.svg";
+import { ReactComponent as ArrowDown } from "../../../resources/svg/ArrowDown.svg";
 import { Droppable } from "react-beautiful-dnd";
 import { updateDroppables } from "../../../slices/currentPlanSlice";
 import ReactTooltip from "react-tooltip";
@@ -44,6 +46,7 @@ function Semester({
   const [display, setDisplay] = useState<boolean>(true);
   const [totalCredits, setTotalCredits] = useState<number>(0);
   const [semesterCourses, setSemesterCourses] = useState<UserCourse[]>([]);
+  const [onHover, setOnHover] = useState<boolean>(false);
 
   // Every time any courses within this semester changes, update total credit count and the list.
   useEffect(() => {
@@ -66,11 +69,6 @@ function Semester({
     setTotalCredits(count);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courses, courses.length]);
-
-  // Sets closed to open and open to closed for course display dropdown
-  const displayCourses = () => {
-    setDisplay(!display);
-  };
 
   // Opens search popup to add new course.
   const addCourse = () => {
@@ -112,8 +110,41 @@ function Semester({
         <div className="flex flex-col h-yearheading font-medium">
           <div className="flex flex-row items-center justify-between px-0.5 py-1 h-yearheading1 bg-white">
             <div
+              className={clsx(
+                "mt-1 h-5 rounded transform duration-150 ease-in",
+                {
+                  "mr-1 h-5 bg-blue-400": onHover,
+                }
+              )}
+              onMouseEnter={() => setOnHover(true)}
+              onMouseLeave={() => setOnHover(false)}
+            >
+              {display ? (
+                <ArrowDown
+                  className={clsx(
+                    "py-auto m-auto h-0 text-white cursor-pointer transform duration-150 ease-in",
+                    {
+                      "h-5": onHover,
+                    }
+                  )}
+                  onClick={() => setDisplay(false)}
+                />
+              ) : (
+                <ArrowUp
+                  className={clsx(
+                    "py-auto m-auto h-0 text-white cursor-pointer transform duration-150 ease-in",
+                    {
+                      "h-5": onHover,
+                    }
+                  )}
+                  onClick={() => setDisplay(true)}
+                />
+              )}
+            </div>
+            <div
               className="flex flex-row items-center w-full h-auto font-normal select-none"
-              onClick={displayCourses}
+              onMouseLeave={() => setOnHover(false)}
+              onMouseEnter={() => setOnHover(true)}
             >
               {semesterName === "Fall"
                 ? "Fall"
@@ -143,7 +174,7 @@ function Semester({
               ) : null}
             </div>
             <div
-              className="group flex flex-row items-center justify-center text-secondary hover:text-white bg-gray-100 hover:bg-white rounded-md"
+              className="group flex flex-row items-center justify-center text-secondary hover:text-white bg-gray-100 hover:bg-white rounded-md cursor-pointer"
               onClick={addCourse}
             >
               <AddSvg className="w-6 h-6 group-hover:text-primary stroke-2" />

--- a/src/components/dashboard/right-column-info/CourseBar.tsx
+++ b/src/components/dashboard/right-column-info/CourseBar.tsx
@@ -138,10 +138,10 @@ function CourseBar({ distribution, general, description }: courseBarProps) {
             <CheckSvg className="absolute left-1/2 top-1/2 w-5 h-5 text-white stroke-2 transform -translate-x-1/2 -translate-y-1/2" />
           ) : null}
         </div>
-        <Add
+        {/* <Add
           className="h-6 transform hover:scale-150 transition duration-200 ease-in"
           onClick={addToDistribution}
-        />
+        /> */}
       </div>
     </>
   );

--- a/src/components/dashboard/right-column-info/FineDistribution.tsx
+++ b/src/components/dashboard/right-column-info/FineDistribution.tsx
@@ -39,9 +39,9 @@ const FineDistribution = ({
   const allCourses = useSelector(selectAllCourses);
   const currPlanCourses = useSelector(selectCurrentPlanCourses);
 
-  const addToDistribution = () => {
-    setDisplayAdd(true);
-  };
+  // const addToDistribution = () => {
+  //   setDisplayAdd(true);
+  // };
 
   const closePopup = () => {
     setDisplayAdd(false);
@@ -94,7 +94,7 @@ const FineDistribution = ({
         </div>
         <p
           className={clsx("pr-2 h-auto", {
-            "overflow-hidden overflow-ellipsis whitespace-nowrap":
+            "overflow-hidden overflow-ellipsis whitespace-nowrap select-text":
               !showDistrDesc,
           })}
         >
@@ -104,10 +104,10 @@ const FineDistribution = ({
       <p className="font-bold">
         {plannedCredits}/{dis.required_credits}
       </p>
-      <Add
+      {/* <Add
         className="h-6 transform hover:scale-150 transition duration-200 ease-in"
         onClick={addToDistribution}
-      />
+      /> */}
       {displayAdd ? (
         <DistributionPopup
           distribution={dis}

--- a/src/components/popups/course-search/Search.tsx
+++ b/src/components/popups/course-search/Search.tsx
@@ -42,7 +42,7 @@ const Search = () => {
     <div className="absolute top-0">
       {/* Background Grey */}
       <div
-        className="fixed z-40 left-0 top-0 m-0 w-full h-screen bg-black"
+        className="fixed z-40 left-0 top-0 m-0 w-full h-screen bg-black transform transition duration-700 ease-in"
         style={{
           opacity: searchOpacity === 100 ? 0.5 : 0,
         }}

--- a/src/components/popups/course-search/query-components/Filters.tsx
+++ b/src/components/popups/course-search/query-components/Filters.tsx
@@ -2,23 +2,16 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Select from "react-select";
 import ReactTooltip from "react-tooltip";
+import { ReactComponent as Question } from "../../../../resources/svg/Question.svg";
 import { all_deps, course_tags } from "../../../../resources/assets";
-import { FilterType, SemesterType } from "../../../../resources/commonTypes";
+import { FilterType } from "../../../../resources/commonTypes";
 import {
   selectSearchFilters,
-  selectYear,
   updateSearchFilters,
-  updateSearchTime,
 } from "../../../../slices/searchSlice";
 
 const creditFilters = ["Any", 0, 1, 2, 3, 4];
 const distributionFilters = ["N", "S", "H", "Q", "E"];
-const termFilters: SemesterType[] = [
-  "Fall",
-  "Spring",
-  "Intersession",
-  "Summer",
-];
 const yearFilters = [2021, 2020, 2019, 2018, 2017];
 const wiFilters = ["Any", "Yes", "No"];
 type filterProps = {
@@ -32,7 +25,6 @@ const Filters = ({ showCriteria }: filterProps) => {
   // Set up redux dispatch and variables.
   const dispatch = useDispatch();
   const searchFilters = useSelector(selectSearchFilters);
-  const year = useSelector(selectYear);
 
   // Update searching for certain amounts of credits
   const handleCreditFilterChange = (event: any): void => {
@@ -57,18 +49,6 @@ const Filters = ({ showCriteria }: filterProps) => {
       filter: "distribution",
       value: areas.length === 0 ? null : areas,
     };
-    dispatch(updateSearchFilters(params));
-  };
-
-  // Update searching for a certain term.
-  const handleTermFilterChange = (event: any): void => {
-    const params: { filter: FilterType; value: any } = {
-      filter: "term",
-      value: event.value,
-    };
-    dispatch(
-      updateSearchTime({ searchSemester: event.value, searchYear: year })
-    );
     dispatch(updateSearchFilters(params));
   };
 
@@ -172,20 +152,14 @@ const Filters = ({ showCriteria }: filterProps) => {
   return (
     <>
       <div className="flex flex-row items-center justify-between mb-2 w-full h-auto">
-        <Select
-          options={[
-            ...termFilters.map((term: any) => ({
-              value: term,
-              label: term,
-            })),
-          ]}
-          className="mx-1 w-40 rounded outline-none"
-          onChange={handleTermFilterChange}
-          value={{
-            value: searchFilters.term,
-            label: searchFilters.term,
-          }}
-        />
+        Version Year
+        <div className="flex flex-row flex-grow">
+          <Question
+            className="fill-gray h-4"
+            data-for="godTip"
+            data-tip={`<p>This is to search for a specific snapshot of course information at a specific time in the past or present.</p><p>NOTE: This is NOT to determine where on the plan you are adding the course.</p><p>(ie. Course Version "Spring, 2021" may not equal "Spring, Senior")</p>`}
+          />
+        </div>{" "}
         <Select
           options={[
             ...yearFilters.map((year: any) => ({
@@ -249,6 +223,15 @@ const Filters = ({ showCriteria }: filterProps) => {
           </div>
           <div className="flex flex-row items-center justify-between mb-2 w-full h-auto">
             Areas
+            <div className="flex-grow">
+              <Question
+                className="h-4"
+                data-for="godTip"
+                data-tip={
+                  "<p>Areas designate the specific subset a course belongs to. Each degree requires students to take a certain amount of credits or courses in a spcific area.</p><p>H - Humanities</p><p>S - Social Sciences</p><p>E - Engineering</p><p>N - Natural Sciences</p><p>Q - Quantitative</p>"
+                }
+              />
+            </div>
             <Select
               isMulti
               options={[
@@ -291,7 +274,16 @@ const Filters = ({ showCriteria }: filterProps) => {
             />
           </div>
           <div className="flex flex-row items-center justify-between mb-2 w-full h-auto">
-            Tag
+            Tag{" "}
+            <div className="flex-grow">
+              <Question
+                className="h-4"
+                data-for="godTip"
+                data-tip={
+                  "<p>Many degree and a few courses require students to complete a specific amount of courses under a certain tag.</p><p>These usually come in the form of 3-4 letters designating department (ie. CSC = Computer Science) followed by 2+ letters signalling the specific subgroup designation within the department (ie. SOFT = Software).</p>"
+                }
+              />
+            </div>
             <div data-tip={getTagString()} data-for="godTip">
               <Select
                 options={[

--- a/src/components/popups/course-search/query-components/Form.tsx
+++ b/src/components/popups/course-search/query-components/Form.tsx
@@ -16,8 +16,8 @@ import {
   SISRetrievedCourse,
   TagType,
 } from "../../../../resources/commonTypes";
-import { ReactComponent as FilterFilledSvg } from "../../../../resources/svg/FilterFilled.svg";
-import { ReactComponent as FilterNonFilledSvg } from "../../../../resources/svg/FilterNonFilled.svg";
+import { ReactComponent as ArrowUp } from "../../../../resources/svg/ArrowUp.svg";
+import { ReactComponent as ArrowDown } from "../../../../resources/svg/ArrowDown.svg";
 import "react-toastify/dist/ReactToastify.css";
 import Filters from "./Filters";
 import { selectAllCourses } from "../../../../slices/userSlice";
@@ -111,6 +111,7 @@ const Form = (props: { setSearching: Function }) => {
 
   // Finds course based on the search conditions given in extras.
   // Finds all relevant courses by starting with all courses and filtering them out.
+  // TODO: Modularize this.
   const find = (extras: SearchExtras): [SISRetrievedCourse[], number[]] => {
     let courses: SISRetrievedCourse[] = [...allCourses];
     if (extras.query.length > 0) {
@@ -358,7 +359,7 @@ const Form = (props: { setSearching: Function }) => {
           onChange={handleSearchTerm}
         />
         <div
-          className="flex flex-none flex-row items-center justify-center w-6 h-6 bg-white rounded cursor-pointer transform hover:scale-110 transition duration-200 ease-in"
+          className="flex flex-none flex-row items-center justify-center w-6 h-6 bg-white rounded-full cursor-pointer transform hover:scale-110 transition duration-200 ease-in"
           onClick={() => setShowCriteria(!showCriteria)}
           data-tip={
             showCriteria ? "Hide search criteria" : "Show search criteria"
@@ -366,9 +367,9 @@ const Form = (props: { setSearching: Function }) => {
           data-for="godTip"
         >
           {!showCriteria ? (
-            <FilterNonFilledSvg className="w-4 h-4 transform rotate-90" />
+            <ArrowUp className="w-4 h-4 transform" />
           ) : (
-            <FilterFilledSvg className="w-4 h-4 transform rotate-90" />
+            <ArrowDown className="w-4 h-4 transform" />
           )}
         </div>
       </div>

--- a/src/components/popups/course-search/query-components/SearchList.tsx
+++ b/src/components/popups/course-search/query-components/SearchList.tsx
@@ -11,6 +11,7 @@ import CourseCard from "./CourseCard";
 import ReactPaginate from "react-paginate";
 import { ReactComponent as PlaceholderFilledSvg } from "../../../../resources/svg/PlaceholderFilled.svg";
 import { ReactComponent as PlaceholderEmptySvg } from "../../../../resources/svg/PlaceholderEmpty.svg";
+import { ReactComponent as Question } from "../../../../resources/svg/Question.svg";
 import { Course } from "../../../../resources/commonTypes";
 import ReactTooltip from "react-tooltip";
 
@@ -120,6 +121,15 @@ const SearchList = (props: { searching: boolean }) => {
           ) : null}
         </div>
         <div className="flex flex-row items-center">
+          <div className="flex-grow mr-1">
+            <Question
+              className="h-4"
+              data-for="godTip"
+              data-tip={
+                "<p>Placeholder course used to flexibly add courses to your plan. Any course not covered by the plan can be added in this way. Just remember to fill out all necessary information of the placeholder course you'd like the plan to count towards!</p><p>Examples:</p><p>- A future 3 credit H course.</p><p>- A required lab safety course of number EN.990.110</p><p>- An AP course covering for the 4 credit course, Calculus I (AS.110.108)</p>"
+              }
+            />
+          </div>
           <div
             className="flex flex-row items-center justify-center px-1 w-auto h-6 bg-white rounded cursor-pointer transform hover:scale-110 transition duration-200 ease-in"
             onClick={onPlaceholderClick}

--- a/src/components/popups/course-search/search-results/CourseVersion.tsx
+++ b/src/components/popups/course-search/search-results/CourseVersion.tsx
@@ -179,7 +179,7 @@ const CourseVersion = (props: { setInspectedArea: Function }) => {
                 </span>
                 <div className="flex flex-row flex-wrap ml-1">
                   {version.tags.length === 0 ? (
-                    "No tags!"
+                    <div className="select-none">No tags!</div>
                   ) : (
                     <>
                       {version.tags.map((tag, i) => (

--- a/src/components/popups/course-search/search-results/CourseVersion.tsx
+++ b/src/components/popups/course-search/search-results/CourseVersion.tsx
@@ -6,6 +6,7 @@ import { getColors } from "../../../../resources/assets";
 import { selectVersion } from "../../../../slices/searchSlice";
 import PrereqDisplay from "../prereqs/PrereqDisplay";
 import CourseEvalSection from "./CourseEvalSection";
+import { ReactComponent as Question } from "../../../../resources/svg/Question.svg";
 
 /**
  * A component showing the specific version of the course at a particular semester/year
@@ -77,7 +78,7 @@ const CourseVersion = (props: { setInspectedArea: Function }) => {
 
   const getAreaName = (area: string): string => {
     if (area === "N") {
-      return "Basic Sciences";
+      return "Natural Sciences";
     } else if (area === "E") {
       return "Engineering";
     } else if (area === "S") {
@@ -120,7 +121,19 @@ const CourseVersion = (props: { setInspectedArea: Function }) => {
             </div>
             <div className="w-auto h-auto">
               <div className="flex flex-row items-center">
-                <div className="mr-1 font-semibold">Areas:</div>
+                <div className="flex flex-row mr-1 font-semibold">
+                  Areas
+                  <div className="flex-grow mt-1">
+                    <Question
+                      className="h-4"
+                      data-for="godTip"
+                      data-tip={
+                        "<p>Areas designate the specific subset a course belongs to. Each degree requires students to take a certain amount of credits or courses in a spcific area.</p><p>H - Humanities</p><p>S - Social Sciences</p><p>E - Engineering</p><p>N - Natural Sciences</p><p>Q - Quantitative</p>"
+                      }
+                    />
+                  </div>
+                  :
+                </div>
                 {version.areas !== "None" ? (
                   version.areas.split("").map((area) => (
                     <div
@@ -151,7 +164,19 @@ const CourseVersion = (props: { setInspectedArea: Function }) => {
                 {version.department}
               </div>
               <div className="flex flex-row w-full h-auto">
-                <span className="font-semibold">Tags: </span>
+                <span className="flex flex-row font-semibold">
+                  Tags
+                  <div className="flex-grow mt-1">
+                    <Question
+                      className="h-4"
+                      data-for="godTip"
+                      data-tip={
+                        "<p>Many degree and a few courses require students to complete a specific amount of courses under a certain tag.</p><p>These usually come in the form of 3-4 letters designating department (ie. CSC = Computer Science) followed by 2+ letters signalling the specific subgroup designation within the department (ie. SOFT = Software).</p>"
+                      }
+                    />
+                  </div>
+                  :{" "}
+                </span>
                 <div className="flex flex-row flex-wrap ml-1">
                   {version.tags.length === 0 ? (
                     "No tags!"

--- a/src/components/popups/course-search/search-results/Placeholder.tsx
+++ b/src/components/popups/course-search/search-results/Placeholder.tsx
@@ -10,6 +10,7 @@ import {
   updatePlaceholder,
   selectSearchStatus,
 } from "../../../../slices/searchSlice";
+import { ReactComponent as Question } from "../../../../resources/svg/Question.svg";
 import Select from "react-select";
 import { all_deps, api, course_tags } from "../../../../resources/assets";
 import { selectCourseToShow } from "../../../../slices/popupSlice";
@@ -19,6 +20,7 @@ import {
   updateCurrentPlanCourses,
   updateSelectedPlan,
 } from "../../../../slices/currentPlanSlice";
+import ReactTooltip from "react-tooltip";
 
 const departmentFilters = ["none", ...all_deps];
 const tagFilters = ["none", ...course_tags];
@@ -170,6 +172,10 @@ const Placeholder = (props: { addCourse: any }) => {
     }
   };
 
+  useEffect(() => {
+    ReactTooltip.rebuild();
+  });
+
   return (
     <div className="flex flex-col h-full font-medium">
       <div className="flex flex-row items-center w-full">
@@ -220,7 +226,18 @@ const Placeholder = (props: { addCourse: any }) => {
           />
         </div>
         <div className="flex flex-col mt-2 w-1/6">
-          Tag
+          <div className="flex flex-row">
+            Tag
+            <div className="flex-grow">
+              <Question
+                className="h-4"
+                data-for="godTip"
+                data-tip={
+                  "<p>Many degree and a few courses require students to complete a specific amount of courses under a certain tag.</p><p>These usually come in the form of 3-4 letters designating department (ie. CSC = Computer Science) followed by 2+ letters signalling the specific subgroup designation within the department (ie. SOFT = Software).</p>"
+                }
+              />
+            </div>
+          </div>
           <Select
             options={[
               ...tagFilters.map((tag: any) => ({ label: tag, value: tag })),
@@ -264,7 +281,18 @@ const Placeholder = (props: { addCourse: any }) => {
           />
         </div>
         <div className="flex flex-col mt-2 w-1/6">
-          Area
+          <div className="flex flex-row">
+            Area
+            <div className="flex-grow">
+              <Question
+                className="h-4"
+                data-for="godTip"
+                data-tip={
+                  "<p>Areas designate the specific subset a course belongs to. Each degree requires students to take a certain amount of credits or courses in a spcific area.</p><p>H - Humanities</p><p>S - Social Sciences</p><p>E - Engineering</p><p>N - Natural Sciences</p><p>Q - Quantitative</p>"
+                }
+              />
+            </div>
+          </div>
           <Select
             options={["none", "N", "S", "H", "E", "Q"].map((area: any) => ({
               label: area,

--- a/src/components/popups/course-search/search-results/SisCourse.tsx
+++ b/src/components/popups/course-search/search-results/SisCourse.tsx
@@ -103,7 +103,7 @@ const SisCourse = (props: SisCourseProps) => {
     <>
       {inspected !== "None" ? (
         <>
-          <div className="pb-5 pt-4 px-5 w-full h-full text-base bg-white rounded overflow-y-auto">
+          <div className="pb-5 pt-4 px-5 w-full h-full text-base bg-white rounded select-text overflow-y-auto">
             {searchStack.length !== 0 ? (
               <button
                 className="focus:outline-none transform hover:scale-125 transition duration-200 ease-in"

--- a/src/components/popups/course-search/search-results/SisCourse.tsx
+++ b/src/components/popups/course-search/search-results/SisCourse.tsx
@@ -2,6 +2,7 @@ import React, { MouseEventHandler, useEffect, useState } from "react";
 // import { ReactComponent as CloseSvg } from "../../../../resources/svg/Close.svg";
 import Select from "react-select";
 import CourseVersion from "./CourseVersion";
+import { ReactComponent as Question } from "../../../../resources/svg/Question.svg";
 import { useDispatch, useSelector } from "react-redux";
 import { selectPlan } from "../../../../slices/currentPlanSlice";
 import {
@@ -12,14 +13,9 @@ import {
   popSearchStack,
   selectVersion,
   updateInspectedVersion,
-  updateSearchFilters,
   updateSearchTime,
 } from "../../../../slices/searchSlice";
-import {
-  FilterType,
-  Course,
-  SemesterType,
-} from "../../../../resources/commonTypes";
+import { Course } from "../../../../resources/commonTypes";
 import ReactTooltip from "react-tooltip";
 import { selectShowCourseInfo } from "../../../../slices/popupSlice";
 
@@ -28,14 +24,6 @@ type SisCourseProps = {
   setInspectedArea: Function;
   addCourse: MouseEventHandler<HTMLButtonElement>;
 };
-
-const termFilters: (SemesterType | "None")[] = [
-  "None",
-  "Fall",
-  "Spring",
-  "Intersession",
-  "Summer",
-];
 
 /**
  * Displays a sis course when searching.
@@ -49,8 +37,6 @@ const SisCourse = (props: SisCourseProps) => {
   const dispatch = useDispatch();
   const inspected = useSelector(selectInspectedCourse);
   const version = useSelector(selectVersion);
-  const semester = useSelector(selectSemester);
-  const year = useSelector(selectYear);
   const currentPlan = useSelector(selectPlan);
   const searchYear = useSelector(selectYear);
   const searchSemester = useSelector(selectSemester);
@@ -80,18 +66,6 @@ const SisCourse = (props: SisCourseProps) => {
     } else {
       return <option value={"None"}>None</option>;
     }
-  };
-
-  // Update searching for a certain term.
-  const handleTermFilterChange = (event: any): void => {
-    const params: { filter: FilterType; value: any } = {
-      filter: "term",
-      value: event.target.value,
-    };
-    dispatch(
-      updateSearchTime({ searchSemester: event.target.value, searchYear: year })
-    );
-    dispatch(updateSearchFilters(params));
   };
 
   // For changing the year to add course while in the search popout.
@@ -154,7 +128,17 @@ const SisCourse = (props: SisCourseProps) => {
               </button> */}
             </div>
             <div className="flex flex-row items-center font-semibold">
-              Term:{" "}
+              <div className="flex flex-row">
+                Term
+                <div className="flex-grow mt-1">
+                  <Question
+                    className="h-4"
+                    data-for="godTip"
+                    data-tip={`<p>This is a specific snapshot of course information at a specific time in the past or present.</p><p>NOTE: This is NOT to determine where on the plan you are adding the course.</p><p>(ie. Course Version "Spring, 2021" may not equal "Spring, Senior")</p>`}
+                  />
+                </div>
+                :
+              </div>
               <Select
                 className="ml-2 w-44"
                 options={inspected.terms.map((term) => {
@@ -175,7 +159,14 @@ const SisCourse = (props: SisCourseProps) => {
                 <div className="mb-1 font-medium">Selecting for</div>
                 <div className="flex tight:flex-col flex-row">
                   <div className="flex flex-row items-center tight:ml-0 tight:mt-2 w-auto h-auto">
-                    Year:
+                    Year
+                    <div className="flex-grow">
+                      <Question
+                        className="h-4"
+                        data-for="godTip"
+                        data-tip={`<p>This is the year you're selecting for.</p><p>The version you are viewing gives you a snapshot of the information of the course at a specific time to give you an understanding of the past and current states of the course. This is NOT to determine where on the plan you are adding the course.</p><p>NOTE: This could be different from the version of the course you are viewing.</p><p>(ie. Course Version "Spring, 2021" may not equal "Spring, Senior")</p>`}
+                      />
+                    </div>
                     <select
                       className="ml-2 text-black text-coursecard rounded focus:outline-none"
                       onChange={handleYearChange}
@@ -189,21 +180,17 @@ const SisCourse = (props: SisCourseProps) => {
                     </select>
                   </div>
                   <div className="flex flex-row items-center tight:ml-0 ml-5 tight:mt-2 w-auto h-auto">
-                    Term:
-                    <select
-                      className="ml-2 h-6 rounded outline-none"
-                      onChange={handleTermFilterChange}
-                      value={semester}
-                    >
-                      {termFilters.map((term) => (
-                        <option key={term + inspected.number} value={term}>
-                          {term}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="flex flex-row items-center tight:ml-0 ml-5 tight:mt-2 w-auto h-auto">
-                    Area:
+                    Area
+                    <div className="flex-grow">
+                      <Question
+                        className="h-4"
+                        data-for="godTip"
+                        data-tip={
+                          "<p>Areas designate the specific subset a course belongs to. Each degree requires students to take a certain amount of credits or courses in a spcific area.</p><p>H - Humanities</p><p>S - Social Sciences</p><p>E - Engineering</p><p>N - Natural Sciences</p><p>Q - Quantitative</p>"
+                        }
+                      />
+                    </div>
+                    :
                     <select
                       className="ml-2 w-14 h-6 rounded outline-none"
                       value={props.inspectedArea}

--- a/src/resources/svg/ArrowDown.svg
+++ b/src/resources/svg/ArrowDown.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+</svg>

--- a/src/resources/svg/ArrowUp.svg
+++ b/src/resources/svg/ArrowUp.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+</svg>

--- a/src/resources/svg/Question.svg
+++ b/src/resources/svg/Question.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 fill-gray" viewBox="0 0 20 20" fill="gray">
+  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+</svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -122,6 +122,11 @@ module.exports = {
       },
       fill: (theme) => ({
         gold: theme("colors.yellow.400"),
+        red: theme("colors.red.500"),
+        green: theme("colors.green.500"),
+        blue: theme("colors.blue.500"),
+        gray: theme("colors.gray.500"),
+        white: theme("colors.white"),
       }),
     },
   },


### PR DESCRIPTION
Arrow Toggling
- Added opening and closing toggling to search filters and plan semesters
![image](https://user-images.githubusercontent.com/65636118/129526043-90e2f9de-b801-423e-98f3-1cd5cd9510e9.png)
![image](https://user-images.githubusercontent.com/65636118/129526138-749af3a2-a1a3-4883-97f8-1cfa9c8eab78.png)

Clarifying descriptions
- Added clarifying descriptions to areas, tags, year versions, year adding, and placeholders
![image](https://user-images.githubusercontent.com/65636118/129526097-6d164263-073c-471f-8957-ee8a88f2ecfa.png)
![image](https://user-images.githubusercontent.com/65636118/129526255-4ca91b67-a2eb-4a05-a7c5-0ab0d00bfecb.png)
![image](https://user-images.githubusercontent.com/65636118/129526292-a50ed0ac-2ad3-48cb-89e9-0d1b245cf06c.png)
![image](https://user-images.githubusercontent.com/65636118/129526341-08e74d2a-47c0-4912-b35f-362a1fbc151f.png)
![image](https://user-images.githubusercontent.com/65636118/129528856-9606c8e1-fe7c-480b-8c3f-711dac57c004.png)

Additional features added
- Made course descriptions selectable.
![image](https://user-images.githubusercontent.com/65636118/129527564-7318a473-bfc8-4a82-8219-cf5fbc0620be.png)
- Removed ability to change semesters in search filter and add course area. Users will now have to click out of search box and search again.