### PR TITLE
feat: React Hydration adds SSR element to uCredit

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import * as serviceWorker from "./serviceWorker";
 import { CookiesProvider } from "react-cookie";
 import { BrowserRouter as Router } from "react-router-dom";
 
-ReactDOM.render(
+ReactDOM.hydrate(
   <React.StrictMode>
     <CookiesProvider>
       <Provider store={store}>


### PR DESCRIPTION
React Hydration
- React by default performs client-side-rendering, meaning that React builds all the html on the browser.
- This has some drawbacks, which include flashing a blank screen on first load as shown in the image below.
![image](https://user-images.githubusercontent.com/65636118/130828677-2aaba277-2cdc-4caf-a69d-c5a484202db5.png)
- By hydrating the app rather than rendering, ReactDOMServer sends a server-side-rendered prepared html file to the frontend, instantly giving users their website.
 - However, overall loading may take a big longer, as React is effectively rendering the html twice: once for a quick SSR version, and the actual site after.
 - This isn't too great of an issue for us, as our website isn't pretty heavy to render to begin with, and is also an interesting addition to the app.
(Shown below, right is SSR and left is CSR)
![image](https://user-images.githubusercontent.com/65636118/130829843-c884052f-16bc-407b-bb0f-71cf9e91ad21.png)

